### PR TITLE
Removed 'GOAT' from Mike's name

### DIFF
--- a/HTML
+++ b/HTML
@@ -21,7 +21,7 @@
           <li>Jimmy</li>
           <li>Jon</li>
           <li>Matt</li>
-          <li>Mike F. (GOAT) </li>
+          <li>Mike F.</li>
           <li>Mike T.</li>
           <li>Rey</li>
           <li>Tommy</li>


### PR DESCRIPTION
Removed GOAT from Mike's name in order to keep format of name's the same.